### PR TITLE
Fixes reference to `alt` for modifier keys

### DIFF
--- a/addon/utils/modifier-key-codes.js
+++ b/addon/utils/modifier-key-codes.js
@@ -2,7 +2,7 @@ import keyCodes from '../utils/key-codes';
 
 // https://en.wikipedia.org/wiki/Modifier_key#Modifier_keys_on_personal_computers
 const modifierKeyCodes = [
-  keyCodes.altLeft,
+  keyCodes.alt,
   keyCodes.cmd,
   keyCodes.contextMenu,
   keyCodes.control,

--- a/tests/unit/utils/modifier-key-codes-test.js
+++ b/tests/unit/utils/modifier-key-codes-test.js
@@ -6,7 +6,7 @@ module('Unit | Utility | modifier key codes');
 test('modifiers are defined', function(assert) {
   assert.expect(1);
 
-  const result = modifierKeyCodes;
+  const result = modifierKeyCodes.compact();
   assert.equal(
     result.length,
     7,


### PR DESCRIPTION
@jordpo 