### PR TITLE
Fix bug with modifier key changes swallowing combos

### DIFF
--- a/addon/services/key-manager.js
+++ b/addon/services/key-manager.js
@@ -159,7 +159,7 @@ export default Ember.Service.extend({
       const keys = get(combo, 'keys').slice();
 
       const verifyModifiers = modifierKeys.every((key) => {
-        return !keys.includes(key) || get(this, `${key}Key`);
+        return !get(this, `${key}Key`) || keys.includes(key);
       });
       keys.removeObjects(modifierKeys);
 

--- a/tests/unit/services/key-manager-test.js
+++ b/tests/unit/services/key-manager-test.js
@@ -311,6 +311,13 @@ test('handles modifierKeys', function(assert) {
       {
         eventName: 'some.eventName',
         keys: [
+          'k',
+        ],
+        priority: 0,
+      },
+      {
+        eventName: 'some.eventName',
+        keys: [
           key,
           'k',
         ],


### PR DESCRIPTION
We need to reverse the boolean expression to ensure that if
modifier is present on event, the combo also has the modifier in it.

@patrickberkeley 