### PR TITLE
Improve Typing Speed

### DIFF
--- a/addon/services/key-manager.js
+++ b/addon/services/key-manager.js
@@ -7,6 +7,7 @@ const {
   $,
   get,
   getOwner,
+  isEmpty,
   run,
   set,
   setProperties,
@@ -141,18 +142,26 @@ export default Ember.Service.extend({
 
   _findComboByName(eventName) {
     const combos = get(this, 'combos');
-    const comboWithName = combos.findBy('eventName', eventName);
-    if (!comboWithName) { return; }
+    const combosWithNameAndKeys = combos
+          .filterBy('eventName', eventName)
+          .filter((combo) => {
+            // Filter for Matching Keys
+            return !isEmpty(this._combosWithKeys([combo]));
+          });
+    const comboWithNameAndKeys = combosWithNameAndKeys
+          .sortBy('priority')
+          .get('lastObject');
 
-    const keyMatchFound = this._combosWithKeys([comboWithName]).length;
-    if (!keyMatchFound) { return; }
+    if (!comboWithNameAndKeys) { return; }
 
     const combosWithKeys = this._combosWithKeys(combos).sortBy('priority');
-    const highestPriority = get(combosWithKeys, 'lastObject.priority');
-    const comboWithNamePriority = get(comboWithName, 'priority');
+    const comboWithKeys = combosWithKeys
+          .sortBy('priority')
+          .get('lastObject');
 
-    if (comboWithNamePriority >= highestPriority) {
-      return comboWithName;
+    // Matching Event is Combo with Highest Priority
+    if (get(comboWithNameAndKeys, 'priority') >= get(comboWithKeys, 'priority')) {
+      return comboWithNameAndKeys;
     }
   },
 

--- a/addon/services/key-manager.js
+++ b/addon/services/key-manager.js
@@ -146,12 +146,12 @@ export default Ember.Service.extend({
 
   _combosWithKeys(combos) {
     const downKeys = get(this, 'downKeys');
+    const pressedModifiers = modifierKeys.filter((key) => {
+      return get(this, `${key}Key`);
+    });
+
     return combos.filter((combo) => {
       const keys = get(combo, 'keys').slice();
-
-      const pressedModifiers = modifierKeys.filter((key) => {
-        return get(this, `${key}Key`);
-      });
       const verifyModifiers = pressedModifiers.every(m => keys.includes(m));
       keys.removeObjects(pressedModifiers);
 

--- a/addon/services/key-manager.js
+++ b/addon/services/key-manager.js
@@ -24,8 +24,10 @@ export default Ember.Service.extend({
   executionKeyClearInterval: 2000,
   matchFound: false,
   uid: 0,
+  altKey: false,
   ctrlKey: false,
   metaKey: false,
+  shiftKey: false,
 
   // config options
   disableOnInput: false,

--- a/addon/services/key-manager.js
+++ b/addon/services/key-manager.js
@@ -118,21 +118,23 @@ export default Ember.Service.extend({
       }
     }
 
+    this._clearDownKeys(event);
+  },
+
+  executionKeys: Ember.computed(function() {
+    return Object.keys(keyCodes).map((key) => {
+      return keyCodes[key];
+    }).reject((code) => {
+      return modifierKeyCodes.includes(code);
+    });
+  }),
+
+  _clearDownKeys(event) {
     if (event.type === 'keyup') {
       get(this, 'downKeys').removeObject(event.keyCode);
     }
 
-    this._clearExecutionKeys();
-  },
-
-  _clearExecutionKeys() {
-    const executionKeys = Object.keys(keyCodes).map((key) => {
-        return keyCodes[key];
-      })
-      .reject((code) => {
-        return modifierKeyCodes.includes(code);
-      });
-    get(this, 'downKeys').removeObjects(executionKeys);
+    get(this, 'downKeys').removeObjects(this.get('executionKeys'));
   },
 
   _findComboByName(eventName) {

--- a/addon/services/key-manager.js
+++ b/addon/services/key-manager.js
@@ -86,6 +86,9 @@ export default Ember.Service.extend({
       const { data, keyCode } = event;
       const { eventName = null } = data;
 
+      if (!modifierKeyCodes.includes(keyCode)) {
+        get(this, 'downKeys').addObject(keyCode);
+      }
       let combo = this._findComboByName(eventName);
       if (!combo) { return; }
 

--- a/addon/utils/combo.js
+++ b/addon/utils/combo.js
@@ -1,0 +1,23 @@
+import Ember from 'ember';
+import modifierKeys from '../utils/modifier-keys';
+
+const {
+  computed,
+  get,
+} = Ember;
+
+export default Ember.Object.extend({
+  modifierKeys: computed('keys', {
+    get() {
+      const keys = get(this, 'keys');
+      return keys.filter(k => modifierKeys.includes(k));
+    },
+  }),
+
+  executionKeys: computed('keys', {
+    get() {
+      const keys = get(this, 'keys');
+      return keys.filter(k => !modifierKeys.includes(k));
+    }
+  }),
+});

--- a/app/utils/combo.js
+++ b/app/utils/combo.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-key-manager/utils/combo';

--- a/tests/unit/services/key-manager-test.js
+++ b/tests/unit/services/key-manager-test.js
@@ -3,6 +3,8 @@ import Ember from 'ember';
 import keyCodes from '../../../utils/key-codes';
 import modifierKeys from '../../../utils/modifier-keys';
 
+import Combo from '../../../utils/combo';
+
 const {
   get,
   run,
@@ -31,7 +33,7 @@ test('handler() executes callback only if event has highest priority', function(
 
   const service = this.subject();
   let priorityComboCallbackCount = 0;
-  const priorityCombo = {
+  const priorityCombo = Combo.create({
     callback() {
       priorityComboCallbackCount += 1;
       assert.ok(
@@ -44,22 +46,22 @@ test('handler() executes callback only if event has highest priority', function(
       'enter',
     ],
     priority: 100,
-  };
+  });
   const combos = [
-    {
+    Combo.create({
       eventName: 'some.eventName.1',
       keys: [
         'enter',
       ],
       priority: 0,
-    },
-    {
+    }),
+    Combo.create({
       eventName: 'some.eventName.2',
       keys: [
         'enter',
       ],
       priority: 10,
-    },
+    }),
     priorityCombo,
   ];
   const enterEvent = {
@@ -70,6 +72,9 @@ test('handler() executes callback only if event has highest priority', function(
   };
 
   set(service, 'combos', combos);
+
+  console.log('combos = ', get(service, 'combos'));
+
   service.handler(enterEvent);
 
   assert.equal(
@@ -253,7 +258,7 @@ test('disableOnInput disables callback if focused on input', function(assert) {
   const done = assert.async();
 
   const service = this.subject();
-  const combo = {
+  const combo = Combo.create({
     callback() {
       assert.ok(true, 'callback is invoked only once.');
     },
@@ -263,7 +268,7 @@ test('disableOnInput disables callback if focused on input', function(assert) {
     ],
     disableOnInput: true,
     priority: 0,
-  };
+  });
   const combos = [
     combo,
   ];
@@ -306,16 +311,17 @@ test('handles modifierKeys', function(assert) {
   };
 
   service.handler(event);
+
   modifierKeys.forEach((key) => {
     const combos = [
-      {
-        eventName: 'some.eventName',
+      Combo.create({
+        eventName: 'some.eventName.0',
         keys: [
           'k',
         ],
         priority: 0,
-      },
-      {
+      }),
+      Combo.create({
         eventName: 'some.eventName',
         keys: [
           key,
@@ -325,7 +331,7 @@ test('handles modifierKeys', function(assert) {
           assert.ok(true, 'event is called.');
         },
         priority: 0,
-      },
+      }),
     ];
     set(service, 'combos', combos);
     set(service, 'matchFound', false);
@@ -335,16 +341,16 @@ test('handles modifierKeys', function(assert) {
   });
 
   const combos = [
-    {
-      eventName: 'some.eventName',
+    Combo.create({
+      eventName: 'some.eventName.2',
       keys: [
         'meta',
         'shift',
         'k',
       ],
       priority: 0,
-    },
-    {
+    }),
+    Combo.create({
       eventName: 'some.eventName',
       keys: [
         'meta',
@@ -354,7 +360,7 @@ test('handles modifierKeys', function(assert) {
         assert.ok(true, 'event is called.');
       },
       priority: 0,
-    },
+    }),
   ];
   set(service, 'combos', combos);
   set(service, 'matchFound', false);

--- a/tests/unit/utils/combo-test.js
+++ b/tests/unit/utils/combo-test.js
@@ -1,0 +1,21 @@
+import Combo from 'dummy/utils/combo';
+import Ember from 'ember';
+import { module, test } from 'qunit';
+
+const { get } = Ember;
+
+module('Unit | Utility | combo');
+
+// Replace this with your real tests.
+test('it works', function(assert) {
+  let result = Combo.create({});
+  assert.ok(result);
+});
+
+test('with keys', function(assert) {
+  let combo = Combo.create({
+    keys: ['alt', 'b']
+  });
+  assert.deepEqual(get(combo, 'executionKeys'), ['b']);
+  assert.deepEqual(get(combo, 'modifierKeys'), ['alt']);
+});


### PR DESCRIPTION
our applications registers a lot of key-manager events in our application. After page render there are over 100 events to manage. A lot of our registered keys can be invoked inside an `input` or `textarea` element, and therefore the speed of checking these registers need to be fast, or else there is a noticeable lag while typing

The largest performance improvement we generated is by `return`ing early in the `_findComboByName()` function. We only want to evaluate priorities for all other combos if the current `event`s `eventName` contains matching key presses.

``` javascript
// function: _findComboByName(eventName) 
const comboWithName = combos.findBy('eventName', eventName);
const keyMatchFound = this._combosWithKeys([comboWithName]).length;
if (!keyMatchFound) return;
```

I would love to see ember-concurrency make its way into this addon. That way we could restart events the next time a keypress comes through. I tried implementing this strategy but did not have any luck, the events were always getting clobbered. Let me know if you'd like to collaborate on this together.

