### PR TITLE
Fires callback if event is triggered within the macro's `element`

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Accepts an object with the following attributes:
 | Name       | Type          | Required | Default  | Description
 | ---------- | ------------- | -------- | -------- | --------- |
 | `callback` | `Function` | Yes | `null` | A function to be called when the macro keys are matched, the `keyEvent` event is fired, and the scope defined by `element` is correct. When called, the `callback` is called with the keyboard `event` that triggered the macro. |
-| `element` | `Element` | No | `document.body` | A DOM element by which to scope the macro. |
+| `element` | `Element` | No | `document.body` | A DOM element by which to scope the macro. Events triggered on _or_ within this element will fire the macro's callback. |
 | `executionKey` | `String` | Yes | `''` | A string that's the value of the key that triggers the macro's callback e.g., to make letter A the execution key, set `executionKey` to `a`. If unsure of a key's value, [use this tool](https://codepen.io/patrickberkeley/full/PEexPY) to it test out. |
 | `isDisabledOnInput` | `Boolean` | No | `false` | A boolean to determine if a macro's the callback should be fired when a `contentEditable`, `input`, `textarea`, or `select` element is focused. |
 | `modifierKeys` | `Array` | No | `[]` | An array of modifier key names. Options are `altKey`, `ctrlKey`, `metaKey`, `shiftKey`. |

--- a/addon/services/key-manager.js
+++ b/addon/services/key-manager.js
@@ -136,7 +136,7 @@ export default Service.extend({
         executionKey,
         modifierKeys,
       } = getProperties(macro, ['element', 'executionKey', 'modifierKeys']);
-      const hasElementMatch = eventElement === element;
+      const hasElementMatch = element === eventElement || element.contains(eventElement);
       const hasExecutionKeyMatch = eventExecutionKey === executionKey;
       const hasModifierKeysMatch = eventModifierKeys.every((key) => {
         return modifierKeys.includes(key);

--- a/tests/unit/services/key-manager-test.js
+++ b/tests/unit/services/key-manager-test.js
@@ -177,11 +177,11 @@ test('`addMacro()`', async function(assert) {
   await dispatchEvent(document.body, firstMacroEvent);   // NO  `assert`
   await dispatchEvent(document.body, secondMacroEvent);  // YES `assert`
   await dispatchEvent(document.body, secondMacroEvent);  // YES `assert`
-  await dispatchEvent(div, secondMacroEvent);            // NO  `assert`
+  await dispatchEvent(div, secondMacroEvent);            // YES `assert`
   await dispatchEvent(document.body, fifthMacroEvent);   // YES `assert`
 
   assert.equal(firstMacroCallCount, 2, 'firstMacro callback is called twice directly');
-  assert.equal(secondMacroCallCount, 3, 'secondMacro callback is called twice directly and once by fifthMacro because it has a higher priority')
+  assert.equal(secondMacroCallCount, 4, 'secondMacro callback is called twice directly, once by the event triggered on a `div` within its `element`, once by fifthMacro because it has a higher priority')
   assert.equal(thirdMacroCallCount, 0, 'thirdMacro callback is not called');
   assert.equal(fourthMacroCallCount, 0, 'fourthMacro callback is not called');
   assert.equal(fifthMacroCallCount, 0, 'fifthMacro callback is not called');


### PR DESCRIPTION
Before this change, events where not triggered when any element in the DOM was
focused (other than the macro's provided `element` scope). This led to
unexpected/undesired behavior of needing to click off of a link after it was
clicked, out of an input when it was focused (even with `isDisabledOnInput` set
to `false`).