### PR TITLE
fix: Do not assume events have an event.key.

### DIFF
--- a/addon/services/key-manager.js
+++ b/addon/services/key-manager.js
@@ -125,7 +125,7 @@ export default Service.extend({
         }));
       const matchingMacros = this._findMatchingMacros(
         event.target,
-        event.key,
+        event.key || '',
         eventModifierKeys,
         event.type
       );


### PR DESCRIPTION
When clicking on an `input[type='text']` autocomplete suggestion, the keyUp event is fired but `event.key` is `undefined`.  This causes some downstream logic that assume `key` is a string to throw.

This is happening in Chrome 71, unsure if it's a recent browser bug or not.